### PR TITLE
Use the same default nonce function as libsecp256k1 for deterministic signatures

### DIFF
--- a/src/math.js
+++ b/src/math.js
@@ -17,10 +17,10 @@ const three = BigInteger.valueOf(3);
 const four = BigInteger.valueOf(4);
 const seven = BigInteger.valueOf(7);
 
-function deterministicGetK0(privateKey, message) {
+function deterministicGetK0(privateKey, publicKey, message) {
   check.checkSignParams(privateKey, message);
 
-  const h = convert.hash(concat([convert.intToBuffer(privateKey), message]));
+  const h = taggedHash('BIP0340/nonce', concat([convert.intToBuffer(privateKey), publicKey, message]));
   const i = convert.bufferToInt(h);
   return i.mod(n);
 }

--- a/src/schnorr.js
+++ b/src/schnorr.js
@@ -28,7 +28,7 @@ function sign(privateKey, message, aux) {
     const rand = math.taggedHash('BIP0340/nonce', concat([t, Px, message]))
     kPrime = convert.bufferToInt(rand).mod(n);
   } else {
-    kPrime = math.deterministicGetK0(d, message);
+    kPrime = math.deterministicGetK0(d, Px, message);
   }
 
   if (kPrime.signum() === 0) {


### PR DESCRIPTION
This PR makes the JS library generate the same deterministic signatures as libsecp256k1 when an aux value is not included. See: https://github.com/bitcoin-core/secp256k1/blob/master/src/modules/schnorrsig/main_impl.h#L50