### PR TITLE
Add capability to accept hex string in sign function

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,15 @@ const schnorr = require('bip-schnorr');
 const convert = schnorr.convert;
 
 // signing
+
+// PrivateKey as BigInteger from bigi or valid hex string
 const privateKey = BigInteger.fromHex('B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF');
+const privateKeyHex = 'B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF';
 const message = Buffer.from('243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89', 'hex');
 const createdSignature = schnorr.sign(privateKey, message);
+const createdSignatureFromHex = schnorr.sign(privateKeyHex, message);
 console.log('The signature is: ' + createdSignature.toString('hex'));
+console.log('The signature is: ' + createdSignatureFromHex.toString('hex'));
 
 // verifying
 const publicKey = Buffer.from('DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659', 'hex');

--- a/src/check.js
+++ b/src/check.js
@@ -58,7 +58,7 @@ function checkPrivateKey(privateKey, idx) {
   }
 
   if (typeof(privateKey) == 'string') {
-    if ((privateKey.match(/[^a-f^A-F^0-9]+/))) {
+    if (privateKey.match(/[^a-f^A-F^0-9]+/)) {
       throw new Error('privateKey must be a BigInteger or valid hex string');
     }
     return

--- a/src/check.js
+++ b/src/check.js
@@ -53,9 +53,17 @@ function checkNonceArr(nonces) {
 
 function checkPrivateKey(privateKey, idx) {
   const idxStr = (idx !== undefined ? '[' + idx + ']' : '');
-  if (!BigInteger.isBigInteger(privateKey)) {
-    throw new Error('privateKey' + idxStr + ' must be a BigInteger');
+  if (!BigInteger.isBigInteger(privateKey) && !(typeof privateKey == 'string')) {
+    throw new Error('privateKey' + idxStr + ' must be a BigInteger or valid hex string');
   }
+
+  if (typeof(privateKey) == 'string') {
+    if ((privateKey.match(/[^a-f^A-F^0-9]+/))) {
+      throw new Error('privateKey must be a BigInteger or valid hex string');
+    }
+    return
+  }
+
   checkRange('privateKey', privateKey);
 }
 

--- a/src/schnorr.js
+++ b/src/schnorr.js
@@ -15,6 +15,7 @@ const zero = BigInteger.ZERO;
 function sign(privateKey, message, aux) {
   // https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#signing
   check.checkSignParams(privateKey, message);
+  privateKey = typeof (privateKey) == 'string' ? BigInteger.fromHex(privateKey) : privateKey;
 
   const P = G.multiply(privateKey);
   const Px = convert.intToBuffer(P.affineX);

--- a/test/schnorr-edge-cases.spec.js
+++ b/test/schnorr-edge-cases.spec.js
@@ -23,7 +23,9 @@ describe('edge cases', () => {
 
   describe('sign', () => {
     it('can check sign params', () => {
-      try { schnorr.sign('foo', m); } catch (e) { assertError(e, 'privateKey must be a BigInteger'); }
+      try { schnorr.sign('foo', m); } catch (e) { assertError(e, 'privateKey must be a BigInteger or valid hex string'); }
+      try { schnorr.sign('abdcefg', m) } catch(e) { assertError(e, 'privateKey must be a BigInteger or valid hex string') };
+      try { schnorr.sign('@!$%', m) } catch(e) { assertError(e, 'privateKey must be a BigInteger or valid hex string') };
       try { schnorr.sign(BigInteger.valueOf(1), 'foo'); } catch (e) { assertError(e, 'message must be a Buffer'); }
       try { schnorr.sign(BigInteger.valueOf(1), Buffer.from([])); } catch (e) { assertError(e, 'message must be 32 bytes long'); }
       try { schnorr.sign(BigInteger.valueOf(0), m); } catch (e) { assertError(e, 'privateKey must be an integer in the range 1..n-1'); }
@@ -32,11 +34,14 @@ describe('edge cases', () => {
     });
     it('can sign example code in README', () => {
       const privateKey = BigInteger.fromHex('B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF');
+      const privateKeyHexString = 'B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF';
       const message = Buffer.from('243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89', 'hex');
       const signatureToVerify = Buffer.from('6D461BEB2F2DA00027D884FD13A24E2AE85CAECCA8AAA2D41777217EC38FB4960A67D47BC4F0722754EDB0E9017072600FFE4030C2E73771DCD3773F46A62652', 'hex');
 
       const createdSignature = schnorr.sign(privateKey, message);
+      const createdSignatureFromPrivKeyString = schnorr.sign(privateKeyHexString, message);
       assert.strictEqual(createdSignature.toString('hex'), signatureToVerify.toString('hex'));
+      assert.strictEqual(createdSignatureFromPrivKeyString.toString('hex'), signatureToVerify.toString('hex'));
     });
   });
 


### PR DESCRIPTION
This PR adds the capability to add in a valid hexadecimal string in the schnorr sign function for ease of use.